### PR TITLE
Verify key type before calling _matchKey in CHECK_CBOR_MATCH_KEY

### DIFF
--- a/src/lib/parser_impl.c
+++ b/src/lib/parser_impl.c
@@ -95,8 +95,10 @@ const char *parser_getErrorDescription(parser_error_t err) {
     size_t numItems; CHECK_CBOR_ERR(cbor_value_get_map_length(map, &numItems)); \
     if (numItems != expected_count)  return parser_unexpected_number_items; }
 
-#define CHECK_CBOR_MATCH_KEY(value, expected_key) \
-    if (!_matchKey(value, expected_key)) return parser_unexpected_field;
+#define CHECK_CBOR_MATCH_KEY(value, expected_key) { \
+  CHECK_CBOR_TYPE(cbor_value_get_type(value), CborTextStringType); \
+  if (!_matchKey(value, expected_key)) return parser_unexpected_field; \
+}
 
 __Z_INLINE parser_error_t _matchKey(CborValue *value, const char *expectedKey) {
     CHECK_CBOR_TYPE(cbor_value_get_type(value), CborTextStringType);


### PR DESCRIPTION
Checking Cbor type inside the `_matchKey` function would return `parser_unexpected_type` in case it didn't match `CborTextStringType`. It would have for effect to have a the check pass even if the key would not match because it would not be a string.